### PR TITLE
caravel link updated

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "caravel"]
+	path = caravel
+	url = https://github.com/efabless/caravel-lite


### PR DESCRIPTION
Signed-off-by: vijayank88 <paruthi143@gmail.com>
Missing caravel link updated as [defines.v](https://github.com/kasirgalabs/kasirga-k0/blob/main/openlane/c0_system_macro/config.tcl) need CARAVEL_ROOT